### PR TITLE
Send metrics data.

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -14,9 +14,11 @@ const configService = require('./config');
 const buildNonTunnelOptions = require('./build-non-tunnel-options')
 const checkNoProxy = require('./no-proxy-parser')
 const empty_buffer = new Buffer(0);
+const onFinished   = require('on-finished');
 
 //opentracing
 var traceHelper = require('./trace-helper');
+let copyOfPluginsReversed = []; 
 //
 
 
@@ -27,6 +29,21 @@ var traceHelper = require('./trace-helper');
  */
 module.exports = function(plugins) {
     const logger = logging.getLogger();
+
+    const METRICS = 'metrics';
+    const ANALYTICS = 'analytics';
+ 
+    copyOfPluginsReversed = plugins.slice().reverse();
+    if(copyOfPluginsReversed && copyOfPluginsReversed[copyOfPluginsReversed.length-1].id === ANALYTICS &&
+    copyOfPluginsReversed[copyOfPluginsReversed.length-2].id === METRICS){
+    
+    let temp = copyOfPluginsReversed[copyOfPluginsReversed.length-1];
+    //swap position of metrics with analytics plugin.
+    copyOfPluginsReversed[copyOfPluginsReversed.length-1] = copyOfPluginsReversed[copyOfPluginsReversed.length-2];
+    copyOfPluginsReversed[copyOfPluginsReversed.length-2] = temp;
+    }
+    debug('Plugin sequence', plugins.map(p => p.id));
+    debug('Reversed plugin sequence', copyOfPluginsReversed.map(p => p.id));
 
     return function(sourceRequest, sourceResponse, next) {
         const startTime = sourceRequest.reqStartTimestamp ||  Date.now();
@@ -51,7 +68,10 @@ module.exports = function(plugins) {
             'header length='+len+' is more than allowed size='+configService.get().edgemicro.maxHttpHeaderSize+', header='+JSON.stringify(sourceRequest.headers));
             //opentracing
             traceHelper.setRequestError('','header length more than allowed size','', 400);
-            //
+            // on failed condition maxHttpHeaderSize, sending metrics data to master node. 
+            if(copyOfPluginsReversed && copyOfPluginsReversed[copyOfPluginsReversed.length-1].id === METRICS){
+                makeMetricsRecord(sourceRequest, sourceResponse);
+            }
             return next(false);
         } else {
             logger.eventLog({
@@ -72,6 +92,11 @@ module.exports = function(plugins) {
                         return next(false);
                     }
                     if (err) {
+                        // on request failed, sending metrics data to master node. 
+                        if(sourceRequest.headers['metrics_record']){
+                            sourceRequest.headers['metrics_record']['proxy_status_code'] = sourceResponse.statusCode;
+                            sendMetricsData(sourceRequest.headers['metrics_record']);
+                        }
                         return next(err)
                     }
                     //opentrace
@@ -85,6 +110,14 @@ module.exports = function(plugins) {
                         (err, targetResponse) => {
 
                             if (err) {
+                                // on target request failed, sending metrics data to master node. 
+                                if(sourceRequest.headers['metrics_record']){
+                                    sourceRequest.headers['metrics_record']['proxy_status_code'] = sourceResponse.statusCode;
+                                    sourceRequest.headers['metrics_record']['target_status_code'] = targetResponse.statusCode;
+                                    sourceRequest.headers['metrics_record']['target_sent_timestamp'] = sourceRequest.headers['target_sent_start_timestamp'];
+                                    sourceRequest.headers['metrics_record']['preflow_time'] = sourceRequest.headers['target_sent_start_timestamp'] - sourceRequest.headers['client_received_start_timestamp'];
+                                    sendMetricsData(sourceRequest.headers['metrics_record']);
+                                }
                                 return next(err);
                             }
                             const options = {
@@ -99,6 +132,14 @@ module.exports = function(plugins) {
                             handleTargetResponse(targetRequest, targetResponse, options, function(err) {
                                 try {
                                     if (err) {
+                                        // on target response failed, sending metrics data to master node. 
+                                        if(sourceRequest.headers['metrics_record']){
+                                            sourceRequest.headers['metrics_record']['proxy_status_code'] = targetResponse.statusCode;
+                                            sourceRequest.headers['metrics_record']['target_status_code'] = targetResponse.statusCode;
+                                            sourceRequest.headers['metrics_record']['target_sent_timestamp'] = sourceRequest.headers['target_sent_start_timestamp'];
+                                            sourceRequest.headers['metrics_record']['preflow_time'] = sourceRequest.headers['target_sent_start_timestamp'] - sourceRequest.headers['client_received_start_timestamp'];
+                                            sendMetricsData(sourceRequest.headers['metrics_record']);
+                                        }
                                         next(err);
                                     } else {
                                         //opentracing
@@ -133,7 +174,6 @@ module.exports = function(plugins) {
  * @private
  */
 function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id, cb) {
-
     const logger = logging.getLogger();
     const config = configService.get();
 
@@ -316,7 +356,6 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
 function handleTargetResponse(targetRequest, targetResponse, options, cb) {
     const start = options.targetStartTime;
     const correlation_id = options.correlation_id;
-    var copyOfPluginsReversed = options.plugins.slice().reverse();
     const plugins = copyOfPluginsReversed;
     const sourceRequest = options.sourceRequest;
     const sourceResponse = options.sourceResponse;
@@ -508,7 +547,12 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
                     d: Date.now() - sourceRequest.reqStartTimestamp || start,
                     component:'plugins-middleware'
                 }, 'sourceResponse' );
-
+                // on finished of responce, sending data to master node 
+                onFinished(sourceResponse, function(err, sourceResponse) {
+                    if(sourceRequest.headers['metrics_record']){
+                        sendMetricsData(sourceRequest.headers['metrics_record']);
+                    }
+                });
                 return cb(err, result);
             });
     });
@@ -616,3 +660,25 @@ const _configured = function(config, property) {
         return true; // on if no config.headers section
     }
 };
+
+function makeMetricsRecord(req, res) {
+    let record = {};
+    record['proxy_name'] = res.proxy.name;
+    record['proxy_url'] = res.proxy.url;
+    record['proxy_basepath'] = res.proxy.base_path;
+    record['target_host'] = req.targetHostname;
+    record['target_url'] = ( req.targetSecure ? 'https' : 'http' ) + 
+                            '://' + req.targetHostname + 
+                            ( req.targetPort ? ':' + req.targetPort : "") + req.targetPath;
+
+    record['proxy_status_code'] = res.statusCode;
+    sendMetricsData(record);
+}
+
+function sendMetricsData(record) {
+    debug('sending metrics record to master node');
+    process.send({
+        type: 'metricsData',
+        data: record
+    });
+}


### PR DESCRIPTION
Add sendMetricsData function for sending metrics plugin data to the master node.
Update plugins sequence to enable 'metrics' plugin after 'analytics' in both preflow and postflow.